### PR TITLE
0.11

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -267,7 +267,7 @@
 
   function headers(xhr) {
     var head = new Headers()
-    var pairs = xhr.getAllResponseHeaders().trim().split('\n')
+    var pairs = (xhr.getAllResponseHeaders() || '').trim().split('\n')
     pairs.forEach(function(header) {
       var split = header.trim().split(':')
       var key = split.shift().trim()

--- a/fetch.js
+++ b/fetch.js
@@ -110,7 +110,7 @@
   var support = {
     blob: 'FileReader' in self && 'Blob' in self && (function() {
       try {
-        new Blob();
+        new Blob()
         return true
       } catch(e) {
         return false
@@ -320,9 +320,9 @@
     return new Response(null, {status: status, headers: {location: url}})
   }
 
-  self.Headers = Headers;
-  self.Request = Request;
-  self.Response = Response;
+  self.Headers = Headers
+  self.Request = Request
+  self.Response = Response
 
   self.fetch = function(input, init) {
     return new Promise(function(resolve, reject) {
@@ -345,7 +345,7 @@
           return xhr.getResponseHeader('X-Request-URL')
         }
 
-        return;
+        return
       }
 
       xhr.onload = function() {
@@ -360,7 +360,7 @@
           headers: headers(xhr),
           url: responseURL()
         }
-        var body = 'response' in xhr ? xhr.response : xhr.responseText;
+        var body = 'response' in xhr ? xhr.response : xhr.responseText
         resolve(new Response(body, options))
       }
 

--- a/fetch.js
+++ b/fetch.js
@@ -368,6 +368,10 @@
         reject(new TypeError('Network request failed'))
       }
 
+      xhr.ontimeout = function() {
+        reject(new TypeError('Network request failed'))
+      }
+
       xhr.open(request.method, request.url, true)
 
       if (request.credentials === 'include') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whatwg-fetch",
   "description": "A window.fetch polyfill.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "fetch.js",
   "repository": "github/fetch",
   "licenses": [

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,7 @@ suite('Headers', function() {
   test('converts field value to string on set and get', function() {
     var headers = new Headers()
     headers.set('Content-Type', 1)
-    headers.set('X-CSRF-Token', undefined);
+    headers.set('X-CSRF-Token', undefined)
     assert.equal(headers.get('Content-Type'), '1')
     assert.equal(headers.get('X-CSRF-Token'), 'undefined')
   })
@@ -193,8 +193,8 @@ suite('Headers', function() {
     assert.throws(function() { new Headers({'<Accept>': ['application/json']}) }, TypeError)
     assert.throws(function() { new Headers({'Accept:': ['application/json']}) }, TypeError)
     assert.throws(function() {
-      var headers = new Headers();
-      headers.set({field: 'value'}, 'application/json');
+      var headers = new Headers()
+      headers.set({field: 'value'}, 'application/json')
     }, TypeError)
   })
   featureDependent(test, !nativeFirefox, 'is iterable with forEach', function() {
@@ -527,11 +527,11 @@ suite('Response', function() {
   })
 
   test('creates Headers object from raw headers', function() {
-    var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}});
-    assert.equal(r.headers instanceof Headers, true);
+    var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})
+    assert.equal(r.headers instanceof Headers, true)
     return r.json().then(function(json){
-      assert.equal(json.foo, 'bar');
-      return json;
+      assert.equal(json.foo, 'bar')
+      return json
     })
   })
 
@@ -574,7 +574,7 @@ suite('Response', function() {
 
   test('redirect creates redirect Response', function() {
     var r = Response.redirect('https://fetch.spec.whatwg.org/', 301)
-    assert(r instanceof Response);
+    assert(r instanceof Response)
     assert.equal(r.status, 301)
     assert.equal(r.headers.get('Location'), 'https://fetch.spec.whatwg.org/')
   })
@@ -949,7 +949,7 @@ suite('Atomic HTTP redirect handling', function() {
 // https://fetch.spec.whatwg.org/#concept-request-credentials-mode
 suite('credentials mode', function() {
   setup(function() {
-    return fetch('/cookie?name=foo&value=reset', {credentials: 'same-origin'});
+    return fetch('/cookie?name=foo&value=reset', {credentials: 'same-origin'})
   })
 
   featureDependent(suite, exerciseMode === 'native', 'omit', function() {
@@ -960,7 +960,7 @@ suite('credentials mode', function() {
 
     test('does not accept cookies with implicit omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar').then(function() {
-        return fetch('/cookie?name=foo', {credentials: 'same-origin'});
+        return fetch('/cookie?name=foo', {credentials: 'same-origin'})
       }).then(function(response) {
         return response.text()
       }).then(function(data) {
@@ -970,7 +970,7 @@ suite('credentials mode', function() {
 
     test('does not accept cookies with omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar', {credentials: 'omit'}).then(function() {
-        return fetch('/cookie?name=foo', {credentials: 'same-origin'});
+        return fetch('/cookie?name=foo', {credentials: 'same-origin'})
       }).then(function(response) {
         return response.text()
       }).then(function(data) {
@@ -980,7 +980,7 @@ suite('credentials mode', function() {
 
     test('does not send cookies with implicit omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar', {credentials: 'same-origin'}).then(function() {
-        return fetch('/cookie?name=foo');
+        return fetch('/cookie?name=foo')
       }).then(function(response) {
         return response.text()
       }).then(function(data) {


### PR DESCRIPTION
un npm i20s
  run `npm audit fix` to fix them, or `npm audit` for details
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN eslint-plugin-github@1.10.0 requires a peer of flow-bin@>=0.70.0 but none is installed. You must install peer dependencies yourself.
npm WARN @typescript-eslint/eslint-plugin@1.13.0 requires a peer of eslint@^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @typescript-eslint/parser@1.13.0 requires a peer of eslint@^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-flowtype@5.2.0 requires a peer of eslint@^7.1.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-jest@23.20.0 requires a peer of eslint@>=5 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-prettier@3.1.4 requires a peer of eslint@>=5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@3.17.1 requires a peer of typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta but none is installed. You must install peer dependencies yourself.

added 684 packages from 1160 contributors and audited 686 packages in 18.507s

34 packages are looking for funding
  run `npm fund` for details

found 4 low severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details