### PR TITLE
Set minimal permissions to github workflows

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,9 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
+
 jobs:
   lock:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: dessant/lock-threads@v2
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,6 +8,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Closes #1272 

## Changes

- lock.yml: only needs issue and pull request write permission according to https://github.com/dessant/lock-threads#examples
- ci.yml: I wasn't able to test it sice it is breaking due to some lint error. Anyway, the workflow does not seem to need more than contents read permission.