### PR TITLE
Fix - File fetching broken since commit 0c1d2b9

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -542,6 +542,12 @@ export function fetch(input, init) {
         statusText: xhr.statusText,
         headers: parseHeaders(xhr.getAllResponseHeaders() || '')
       }
+      // This check if specifically for when a user fetches a file locally from the file system
+      if (request.url.startsWith('file://')) {
+        options.status = 200;
+      } else {
+        options.status = xhr.status;
+      }
       options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
       var body = 'response' in xhr ? xhr.response : xhr.responseText
       setTimeout(function() {

--- a/fetch.js
+++ b/fetch.js
@@ -470,7 +470,9 @@ export function Response(bodyInit, options) {
 
   this.type = 'default'
   this.status = options.status === undefined ? 200 : options.status
-  if (this.status < 200 || this.status > 599) {
+
+  if ((this.status < 200 || this.status > 599) && !this.request.url.startsWith('file://')) {
+    // Certain devices don't return a status when fetching a file
     throw new RangeError("Failed to construct 'Response': The status provided (0) is outside the range [200, 599].")
   }
   this.ok = this.status >= 200 && this.status < 300
@@ -538,15 +540,11 @@ export function fetch(input, init) {
 
     xhr.onload = function() {
       var options = {
+        status: xhr.status,
         statusText: xhr.statusText,
         headers: parseHeaders(xhr.getAllResponseHeaders() || '')
       }
-      // This check if specifically for when a user fetches a file locally from the file system
-      if (request.url.startsWith('file://')) {
-        options.status = 200;
-      } else {
-        options.status = xhr.status;
-      }
+
       options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
       var body = 'response' in xhr ? xhr.response : xhr.responseText
       setTimeout(function() {

--- a/fetch.js
+++ b/fetch.js
@@ -538,7 +538,6 @@ export function fetch(input, init) {
 
     xhr.onload = function() {
       var options = {
-        status: xhr.status,
         statusText: xhr.statusText,
         headers: parseHeaders(xhr.getAllResponseHeaders() || '')
       }

--- a/fetch.js
+++ b/fetch.js
@@ -543,7 +543,7 @@ export function fetch(input, init) {
       }
       // This check if specifically for when a user fetches a file locally from the file system
       // Only if the status is out of a normal range
-      if (request.url.startsWith('file://') && xhr.status < 200 || xhr.status > 599) {
+      if (request.url.startsWith('file://') && (xhr.status < 200 || xhr.status > 599)) {
         options.status = 200;
       } else {
         options.status = xhr.status;

--- a/fetch.js
+++ b/fetch.js
@@ -470,9 +470,7 @@ export function Response(bodyInit, options) {
 
   this.type = 'default'
   this.status = options.status === undefined ? 200 : options.status
-
-  if ((this.status < 200 || this.status > 599) && !this.request.url.startsWith('file://')) {
-    // Certain devices don't return a status when fetching a file
+  if (this.status < 200 || this.status > 599) {
     throw new RangeError("Failed to construct 'Response': The status provided (0) is outside the range [200, 599].")
   }
   this.ok = this.status >= 200 && this.status < 300
@@ -540,11 +538,15 @@ export function fetch(input, init) {
 
     xhr.onload = function() {
       var options = {
-        status: xhr.status,
         statusText: xhr.statusText,
         headers: parseHeaders(xhr.getAllResponseHeaders() || '')
       }
-
+      // This check if specifically for when a user fetches a file locally from the file system
+      if (request.url.startsWith('file://')) {
+        options.status = 200;
+      } else {
+        options.status = xhr.status;
+      }
       options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
       var body = 'response' in xhr ? xhr.response : xhr.responseText
       setTimeout(function() {

--- a/fetch.js
+++ b/fetch.js
@@ -542,7 +542,8 @@ export function fetch(input, init) {
         headers: parseHeaders(xhr.getAllResponseHeaders() || '')
       }
       // This check if specifically for when a user fetches a file locally from the file system
-      if (request.url.startsWith('file://')) {
+      // Only if the status is out of a normal range
+      if (request.url.startsWith('file://') && xhr.status < 200 || xhr.status > 599) {
         options.status = 200;
       } else {
         options.status = xhr.status;

--- a/test/test.js
+++ b/test/test.js
@@ -647,6 +647,10 @@ exercise.forEach(function(exerciseMode) {
             new Response('', {status: i})
           })
         }
+        // Check that no error is thrown for file:// URLs
+        assert.doesNotThrow(function() {
+          new Response('', {status: 0, request: {url: 'file://path/to/local/file'}})
+        })
       })
       test('when request url starts with "file://", status should be 200', function() {
         var request = { url: 'file://path/to/local/file' };

--- a/test/test.js
+++ b/test/test.js
@@ -647,6 +647,13 @@ exercise.forEach(function(exerciseMode) {
             new Response('', {status: i})
           })
         }
+        // A fetch with the url of a `file://` scheme may have a status 0 or
+        // similar in some operating systems. In the event that a status is found outside 
+        // the standard range of 200-599, and the url start with `file://`
+        // the status should return 200
+        assert.doesNotThrow(function() {
+          new Request('', {status: 0, request: {url: 'file://path/to/local/file'}})
+        })
       })
 
       test('when request url starts with "file://", status should be 200', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -656,17 +656,6 @@ exercise.forEach(function(exerciseMode) {
         })
       })
 
-      test('when request url starts with "file://", status should be 200', function() {
-        var request = { url: 'file://path/to/local/file' };
-        var options = { status: 404 };
-
-        if (request.url.startsWith('file://')) {
-          options.status = 200;
-        }
-
-        assert.equal(options.status, 200);
-      });
-
       test('creates Headers object from raw headers', function() {
         var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})
         assert.equal(r.headers instanceof Headers, true)

--- a/test/test.js
+++ b/test/test.js
@@ -647,11 +647,18 @@ exercise.forEach(function(exerciseMode) {
             new Response('', {status: i})
           })
         }
-        // Check that no error is thrown for file:// URLs
-        assert.doesNotThrow(function() {
-          new Response('', {status: 0, request: {url: 'file://path/to/local/file'}})
-        })
       })
+
+      test('when request url starts with "file://", status should be 200', function() {
+        var request = { url: 'file://path/to/local/file' };
+        var options = { status: 404 };
+
+        if (request.url.startsWith('file://')) {
+          options.status = 200;
+        }
+
+        assert.equal(options.status, 200);
+      });
 
       test('creates Headers object from raw headers', function() {
         var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})

--- a/test/test.js
+++ b/test/test.js
@@ -652,16 +652,6 @@ exercise.forEach(function(exerciseMode) {
           new Response('', {status: 0, request: {url: 'file://path/to/local/file'}})
         })
       })
-      test('when request url starts with "file://", status should be 200', function() {
-        var request = { url: 'file://path/to/local/file' };
-        var options = { status: 404 };
-
-        if (request.url.startsWith('file://')) {
-          options.status = 200;
-        }
-
-        assert.equal(options.status, 200);
-      });
 
       test('creates Headers object from raw headers', function() {
         var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})

--- a/test/test.js
+++ b/test/test.js
@@ -648,6 +648,17 @@ exercise.forEach(function(exerciseMode) {
           })
         }
       })
+      test('when request url starts with "file://", status should be 200', function() {
+        var request = { url: 'file://path/to/local/file' };
+        var options = { status: 404 };
+
+        if (request.url.startsWith('file://')) {
+          options.status = 200;
+        }
+
+        assert.equal(options.status, 200);
+      });
+
       test('creates Headers object from raw headers', function() {
         var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})
         assert.equal(r.headers instanceof Headers, true)


### PR DESCRIPTION
#1371 
As noted in 1371, and other discussion outside of whatwg/fetch, it's been found that adding the RangeError for statuses outside of 200-599 causes local File fetches to fail.

i.e.
fetch("file://some/local/path")

This PR adds a simple check for the file path before returning the response, it could alternatively be added to the 200/500 check as a not condition.

Not sure if this has the potential to break other things, or if there's a better way to handle the RangeError issue with `file://` not setting a status.

Test: In it's current state, I'm unsure how to test this, as most browsers block the use of `file://` and any systems that allow may return a status, and may not.

Thanks