### PR TITLE
fix: Have unique error messages for xhr timeouts and errors

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -563,7 +563,7 @@ export function fetch(input, init) {
 
     xhr.ontimeout = function() {
       setTimeout(function() {
-        reject(new TypeError('Network request failed'))
+        reject(new TypeError('Network request timed out'))
       }, 0)
     }
 


### PR DESCRIPTION
Both `xhr.onerror` and `xhr.ontimeout` throw the same error.

I think it would be beneficial to have both handler emit errors with a different message. This way, applications can behave differently based on the error message. Especially since there is no such thing as a unique error code do distinguish both errors.