### PR TITLE
Fix workflows to run on main instead of master

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '17 14 * * 1'
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '17 14 * * 1'
   push:
-    branches: [ "main" ]
+    branches: [ main ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Hi, just a minor fix to the workflows to run on push at main, they were still looking for pushes on "master".