### PR TITLE
Replaced startsWith with indexOf to Avoid Additional Polyfill Dependencies

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -543,7 +543,7 @@ export function fetch(input, init) {
       }
       // This check if specifically for when a user fetches a file locally from the file system
       // Only if the status is out of a normal range
-      if (request.url.startsWith('file://') && (xhr.status < 200 || xhr.status > 599)) {
+      if (request.url.indexOf('file://') === 0 && (xhr.status < 200 || xhr.status > 599)) {
         options.status = 200;
       } else {
         options.status = xhr.status;


### PR DESCRIPTION
PR will resolve https://github.com/JakeChampion/fetch/issues/1403

Since startsWith has a similar level of support as fetch, we have replaced it with indexOf to ensure that the module does not require additional polyfills.