### PR TITLE
Fix: Response.error().ok === false

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -493,6 +493,7 @@ Response.prototype.clone = function() {
 
 Response.error = function() {
   var response = new Response(null, {status: 200, statusText: ''})
+  response.ok = false
   response.status = 0
   response.type = 'error'
   return response

--- a/test/test.js
+++ b/test/test.js
@@ -696,6 +696,7 @@ exercise.forEach(function(exerciseMode) {
       test('error creates error Response', function() {
         var r = Response.error()
         assert(r instanceof Response)
+        assert.equal(r.ok, false)
         assert.equal(r.status, 0)
         assert.equal(r.statusText, '')
         assert.equal(r.type, 'error')


### PR DESCRIPTION
## Summary
- Fixes error caused in https://github.com/JakeChampion/fetch/commit/0c1d2b97b7edf636323534b13626a8bb9f5fe22d, by which `Response.error().ok === true` where it should be `false` because `Response.error().status < 200`.
- Adds test assertion

## Explanation
`Response.error` internally constructs a valid Response and overwrites properties as necessary.

Now that `Response` must be constructed with a valid status, the constructed Response will be `ok`, so this property needs to be overwritten as well.